### PR TITLE
BLAH-950: Remove options from StringToInt

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// StringToInt : returns a int from a string value
-func StringToInt(num string, alpha string, options ...bool) (int, error) {
+// StringToInt : returns an int from a string value
+func StringToInt(num string, alpha string) (int, error) {
 	ISO, err := GetISOFromAlpha(alpha)
 	if err != nil {
 		return 0, err
@@ -24,16 +24,17 @@ func StringToInt(num string, alpha string, options ...bool) (int, error) {
 	// Validate ISO fraction matches
 	split := strings.Split(str, ".")
 
-	// Check valid fraction match
-	allowLoose := false
-	if len(options) >= 1 {
-		allowLoose = options[0]
+	if len(split) > 2 {
+		return 0, ErrorInvalidStringFormat
 	}
-	if ISO.Fraction != 0 {
-		if !allowLoose && len(split) == 2 && len(split[1]) != ISO.Fraction {
-			return 0, ErrorInvalidISOFractionMatch
-		}
 
+	// If decimal is longer than ISO fraction, remove excess digits
+	if len(split) == 2 && len(split[1]) > ISO.Fraction {
+		split[1] = split[1][:ISO.Fraction]
+		str = strings.Join(split, ".")
+	}
+
+	if ISO.Fraction != 0 {
 		// Convert to Float - to test if valid number
 		fl, err := strconv.ParseFloat(str, 64)
 		if err != nil {

--- a/currency_test.go
+++ b/currency_test.go
@@ -44,6 +44,8 @@ var TestStringToIntData = []struct {
 	{"42.9900", "USD", 4299},
 	{"42.2360", "USD", 4223},
 	{"$5.999", "USD", 599},
+	{"$42.0000", "USD", 4200},
+	{"$42.9900", "USD", 4299},
 
 	// Problematic Numbers
 	{"$538.92", "USD", 53892},

--- a/currency_test.go
+++ b/currency_test.go
@@ -6,70 +6,71 @@ import (
 )
 
 var TestStringToIntData = []struct {
-	Num        string
-	Alpha      string
-	AllowLoose bool
-	Output     interface{}
+	Num    string
+	Alpha  string
+	Output interface{}
 }{
 	// Invalid values
-	{"", "USD", false, ErrorInvalidStringFormat.Error()},
-	{"     ", "USD", false, ErrorInvalidStringFormat.Error()},
-	{"abcd", "USD", false, ErrorInvalidStringFormat.Error()},
-	{"$5", "USA", false, ErrorInvalidISO.Error()},
-	{"$0.0.5", "USD", false, ErrorInvalidStringFormat.Error()},
-	{"$5.0", "USD", false, ErrorInvalidISOFractionMatch.Error()},
-	{"$5.000", "USD", false, ErrorInvalidISOFractionMatch.Error()},
-
-	//  Loose Validation tests
-	{"$5.1", "USD", true, 510},
-	{"$5.", "USD", true, 500},
-	{"$5.001", "USD", true, 500},
-	{"$5.101", "USD", true, 510},
+	{"", "USD", ErrorInvalidStringFormat.Error()},
+	{"     ", "USD", ErrorInvalidStringFormat.Error()},
+	{"abcd", "USD", ErrorInvalidStringFormat.Error()},
+	{"$5", "USA", ErrorInvalidISO.Error()},
+	{"$0.0.5", "USD", ErrorInvalidStringFormat.Error()},
 
 	// Various Standard values
-	{"$5", "USD", false, 500},
-	{"$500", "USD", false, 50000},
-	{"$-500", "USD", false, -50000},
-	{"$05", "USD", false, 500},
-	{"$0.05", "USD", false, 5},
-	{"$5.52", "USD", false, 552},
-	{"$0.00", "USD", false, 0},
-	{"$0.01", "USD", false, 1},
-	{"$0.10", "USD", false, 10},
-	{"$1.00", "USD", false, 100},
-	{"$10.00", "USD", false, 1000},
-	{"$100.00", "USD", false, 10000},
-	{"$1,000.00", "USD", false, 100000},
-	{"$10,000.00", "USD", false, 1000000},
-	{"$100,000.00", "USD", false, 10000000},
-	{"$1,000,000.00", "USD", false, 100000000},
+	{"$5", "USD", 500},
+	{"$500", "USD", 50000},
+	{"$-500", "USD", -50000},
+	{"$05", "USD", 500},
+	{"$0.05", "USD", 5},
+	{"$5.52", "USD", 552},
+	{"$0.00", "USD", 0},
+	{"$0.01", "USD", 1},
+	{"$0.10", "USD", 10},
+	{"$1.00", "USD", 100},
+	{"$10.00", "USD", 1000},
+	{"$100.00", "USD", 10000},
+	{"$1,000.00", "USD", 100000},
+	{"$10,000.00", "USD", 1000000},
+	{"$100,000.00", "USD", 10000000},
+	{"$1,000,000.00", "USD", 100000000},
+
+	//  Poorly formatted numbers
+	{"$5.1", "USD", 510},
+	{"$5.", "USD", 500},
+	{"$5.000", "USD", 500},
+	{"$5.001", "USD", 500},
+	{"$5.101", "USD", 510},
+	{"42.9900", "USD", 4299},
+	{"42.2360", "USD", 4223},
+	{"$5.999", "USD", 599},
 
 	// Problematic Numbers
-	{"$538.92", "USD", false, 53892},
-	{"$65.85", "USD", false, 6585},
-	{"$17.99", "USD", false, 1799},
-	{"538.92", "USD", false, 53892},
-	{"65.85", "USD", false, 6585},
-	{"17.99", "USD", false, 1799},
-	{"$-538.92", "USD", false, -53892},
-	{"$-65.85", "USD", false, -6585},
-	{"$-17.99", "USD", false, -1799},
-	{"-538.92", "USD", false, -53892},
-	{"-65.85", "USD", false, -6585},
-	{"-17.99", "USD", false, -1799},
-	{"-$538.92", "USD", false, -53892},
-	{"-$65.85", "USD", false, -6585},
-	{"-$17.99", "USD", false, -1799},
+	{"$538.92", "USD", 53892},
+	{"$65.85", "USD", 6585},
+	{"$17.99", "USD", 1799},
+	{"538.92", "USD", 53892},
+	{"65.85", "USD", 6585},
+	{"17.99", "USD", 1799},
+	{"$-538.92", "USD", -53892},
+	{"$-65.85", "USD", -6585},
+	{"$-17.99", "USD", -1799},
+	{"-538.92", "USD", -53892},
+	{"-65.85", "USD", -6585},
+	{"-17.99", "USD", -1799},
+	{"-$538.92", "USD", -53892},
+	{"-$65.85", "USD", -6585},
+	{"-$17.99", "USD", -1799},
 
 	// Non USD
-	{"$100.00,00", "ARS", false, 1000000},
-	{"$10,000,000", "JPY", false, 10000000},
+	{"$100.00,00", "ARS", 1000000},
+	{"$10,000,000", "JPY", 10000000},
 }
 
 func TestStringToInt(t *testing.T) {
 	// Test various structs
 	for _, v := range TestStringToIntData {
-		result, err := StringToInt(v.Num, v.Alpha, v.AllowLoose)
+		result, err := StringToInt(v.Num, v.Alpha)
 		if err != nil {
 			if err.Error() != v.Output {
 				t.Error("Expected:", v.Output, "Error:", err.Error())
@@ -95,13 +96,6 @@ func BenchmarkStringToInt(b *testing.B) {
 	// run the Fib function b.N times
 	for n := 0; n < b.N; n++ {
 		StringToInt("12,345,678.99", "USD")
-	}
-}
-
-func BenchmarkStringToIntLoose(b *testing.B) {
-	// run the Fib function b.N times
-	for n := 0; n < b.N; n++ {
-		StringToInt("12,345,678.99", "USD", true)
 	}
 }
 


### PR DESCRIPTION
- This change also removes any excess digits:

For example:
"42.299" -> 4229
"42.0000" -> 4200
"42.9900" -> 4299